### PR TITLE
Replace stringified arrow functions with inline functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const md = require('markdown-it')({
 
 const stringify = (src) => JSON.stringify(src).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
 
-let vueCompilerStripWith
+let vueCompiler
 try {
-  vueCompilerStripWith = require('vue-template-es2015-compiler')
+  vueCompiler = require('vue-template-es2015-compiler')
 } catch (err) {
 }
 
@@ -31,14 +31,14 @@ module.exports = function (source) {
     html: ${stringify(fm.html)},
     attributes: ${stringify(fm.attributes)}`;
 
-  if (!!options.vue && vueCompilerStripWith) {
+  if (!!options.vue && vueCompiler) {
     const rootClass = options.vue.root || "frontmatter-markdown"
-    const compiled = vueCompilerStripWith.compile(`<div class="${rootClass}">${fm.html}</div>`)
-    const render = `return ${vueCompilerStripWith(`function render() { ${compiled.render} }`)}`
+    const compiled = vueCompiler.compile(`<div class="${rootClass}">${fm.html}</div>`)
+    const render = `return ${vueCompiler(`function render() { ${compiled.render} }`)}`
 
     let staticRenderFns = '';
     if (compiled.staticRenderFns.length > 0) {
-      staticRenderFns = `return ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(function(fn) { return `function () { ${fn} }` }).join(',')}]`)}`
+      staticRenderFns = `return ${vueCompiler(`[${compiled.staticRenderFns.map(function(fn) { return `function () { ${fn} }` }).join(',')}]`)}`
     }
 
     output += `,
@@ -55,8 +55,8 @@ module.exports = function (source) {
             return this.templateRender ? this.templateRender() : createElement("div", "Rendering");
           },
           created () {
-            this.templateRender = ${vueCompilerStripWith(`function render() { ${compiled.render} }`)};
-            this.$options.staticRenderFns = ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(function(fn) { return `function () { ${fn} }` }).join(',')}]`)};
+            this.templateRender = ${vueCompiler(`function render() { ${compiled.render} }`)};
+            this.$options.staticRenderFns = ${vueCompiler(`[${compiled.staticRenderFns.map(function(fn) { return `function () { ${fn} }` }).join(',')}]`)};
           }
         }
       }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function (source) {
 
     let staticRenderFns = '';
     if (compiled.staticRenderFns.length > 0) {
-      staticRenderFns = `return ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(fn => `function () { ${fn} }`).join(',')}]`)}`
+      staticRenderFns = `return ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(function(fn) { return `function () { ${fn} }` }).join(',')}]`)}`
     }
 
     output += `,
@@ -57,7 +57,7 @@ module.exports = function (source) {
           },
           created () {
             this.templateRender = ${vueCompilerStripWith(`function render() { ${compiled.render} }`)};
-            this.$options.staticRenderFns = ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(fn => `function () { ${fn} }`).join(',')}]`)};
+            this.$options.staticRenderFns = ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(function(fn) { return `function () { ${fn} }` }).join(',')}]`)};
           }
         }
       }

--- a/index.js
+++ b/index.js
@@ -7,9 +7,8 @@ const md = require('markdown-it')({
 
 const stringify = (src) => JSON.stringify(src).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
 
-let vueCompiler, vueCompilerStripWith
+let vueCompilerStripWith
 try {
-  vueCompiler = require('vue-template-compiler')
   vueCompilerStripWith = require('vue-template-es2015-compiler')
 } catch (err) {
 }
@@ -32,9 +31,9 @@ module.exports = function (source) {
     html: ${stringify(fm.html)},
     attributes: ${stringify(fm.attributes)}`;
 
-  if (!!options.vue && vueCompiler && vueCompilerStripWith) {
+  if (!!options.vue && vueCompilerStripWith) {
     const rootClass = options.vue.root || "frontmatter-markdown"
-    const compiled = vueCompiler.compile(`<div class="${rootClass}">${fm.html}</div>`)
+    const compiled = vueCompilerStripWith.compile(`<div class="${rootClass}">${fm.html}</div>`)
     const render = `return ${vueCompilerStripWith(`function render() { ${compiled.render} }`)}`
 
     let staticRenderFns = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1717,13 +1717,6 @@
         }
       }
     },
-    "de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
-      "dev": true,
-      "optional": true
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2310,12 +2303,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2330,17 +2325,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2457,7 +2455,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2469,6 +2468,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2483,6 +2483,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2490,12 +2491,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2514,6 +2517,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2594,7 +2598,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2606,6 +2611,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2727,6 +2733,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3007,13 +3014,6 @@
           }
         }
       }
-    },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true,
-      "optional": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -6618,22 +6618,10 @@
         }
       }
     },
-    "vue-template-compiler": {
-      "version": "2.5.17",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
-      "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "de-indent": "^1.0.2",
-        "he": "^1.1.0"
-      }
-    },
     "vue-template-es2015-compiler": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
-      "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
-      "dev": true
+      "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "dependencies": {
     "front-matter": "^3.0.0",
     "loader-utils": "^1.1.0",
-    "markdown-it": "^8.4.2",
-    "vue-template-es2015-compiler": "^1.6.0"
+    "markdown-it": "^8.4.2"
   },
   "optionalDependencies": {
     "vue-template-es2015-compiler": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "front-matter": "^3.0.0",
     "loader-utils": "^1.1.0",
-    "markdown-it": "^8.4.2"
+    "markdown-it": "^8.4.2",
+    "vue-template-es2015-compiler": "^1.6.0"
   },
   "optionalDependencies": {
-    "vue-template-compiler": "^2.5.0",
     "vue-template-es2015-compiler": "^1.6.0"
   },
   "devDependencies": {
@@ -39,7 +39,6 @@
     "node-eval": "^2.0.0",
     "vue": "^2.5.17",
     "vue-jest": "^2.6.0",
-    "vue-template-compiler": "^2.5.17",
     "vue-template-es2015-compiler": "^1.6.0"
   },
   "jest": {


### PR DESCRIPTION
The aim is to be able to use this in browsers that don't support arrow functions. Because they are stringified, they don't get transpiled by Babel.