### PR TITLE
Set data to be function that doesn't transpile to arrow function

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (source) {
         render: ${stringify(render)},
         staticRenderFns: ${stringify(staticRenderFns)},
         component: {
-          data () {
+          data: function () {
             return {
               templateRender: null
             }

--- a/index.js
+++ b/index.js
@@ -52,10 +52,10 @@ module.exports = function (source) {
               templateRender: null
             }
           },
-          render (createElement) {
+          render: function (createElement) {
             return this.templateRender ? this.templateRender() : createElement("div", "Rendering");
           },
-          created () {
+          created: function () {
             this.templateRender = ${vueCompilerStripWith(`function render() { ${compiled.render} }`)};
             this.$options.staticRenderFns = ${vueCompilerStripWith(`[${compiled.staticRenderFns.map(fn => `function () { ${fn} }`).join(',')}]`)};
           }


### PR DESCRIPTION
This should be a better approach (than my previous pull request).

This way, `data`, `created` and `render` will all compile down to backwards compatible JS.