### PR TITLE
Move meta attributes to the top level

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,17 +27,15 @@ module.exports = function (source) {
     fm.html = md.render(fm.body);
   }
 
-  const attributes = {
-    ...fm.attributes,
-    _meta: {
-      resourcePath: this.resourcePath
-    }
+  const meta = {
+    resourcePath: this.resourcePath
   };
 
   let output = `
     body: ${stringify(fm.body)},
     html: ${stringify(fm.html)},
-    attributes: ${stringify(attributes)}`;
+    attributes: ${stringify(fm.attributes)},
+    meta: ${stringify(meta)}`;
 
   if (!!options.vue && vueCompiler && vueCompilerStripWith) {
     const rootClass = options.vue.root || "frontmatter-markdown"

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -70,10 +70,13 @@ describe("frontmatter-markdown-loader", () => {
     it("returns frontmatter object for 'attributes' property", () => {
       expect(loaded.attributes).toEqual({
         subject: "Hello",
-        tags: ["tag1", "tag2"],
-        _meta: {
-          resourcePath: "/somewhere/frontmatter.md"
-        }
+        tags: ["tag1", "tag2"]
+      });
+    });
+
+    it("returns meta data on 'meta' property", () => {
+      expect(loaded.meta).toEqual({
+        resourcePath: "/somewhere/frontmatter.md"
       });
     });
 


### PR DESCRIPTION
Resolves #50

By introducing `attributes._meta`, `attributes` returns JS Object forcibly what if frontmatter returns  Array on the top level. This was an unintentional breaking change and this PR restores that by moving `attributes._meta` to `meta` (on the top-level).