### PR TITLE
Add new mode to import markdown content as React component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # frontmatter-markdown-loader [![frontmatter-markdown-loader Dev Token](https://badge.devtoken.rocks/frontmatter-markdown-loader)](https://devtoken.rocks/package/frontmatter-markdown-loader)
 
 [![npm](https://img.shields.io/npm/v/frontmatter-markdown-loader.svg?style=for-the-badge)](https://www.npmjs.com/package/frontmatter-markdown-loader)
-[![CircleCI](https://img.shields.io/circleci/project/github/hmsk/frontmatter-markdown-loader/master.svg?style=for-the-badge)](https://circleci.com/gh/hmsk/frontmatter-markdown-loader/tree/master)
 
+Webpack Loader for [Front Matter](https://jekyllrb.com/docs/front-matter/) files (.md) which returns:
 
-Webpack Loader for: FrontMatter (.md) which returns Compiled HTML + Attributes (+ [Object compiled as a Vue component](https://hmsk.github.io/frontmatter-markdown-loader/vue.html))
+- Front Matter attributes
+- Compiled markdown as HTML
+- [Compiled markdown as a React component](https://hmsk.github.io/frontmatter-markdown-loader/react.html))
+- [Compiled markdown as a Vue component](https://hmsk.github.io/frontmatter-markdown-loader/vue.html))
 
 This FrontMatter markdown file `something.md`:
 
@@ -27,9 +30,9 @@ import fm from "something.md"
 
 fm.attributes // FrontMatter attributes => { subject: "Hello", tags: ["tag1", "tag2"] }
 fm.html // Compiled markdown as HTML => "<h1>Title</h1>\n<p>message</p>\n"
+fm.react // Component function for React which renders compiled markdown (Disabled as default)
+fm.vue.compoennt // Extendable component object for Vue which renders compiled markdown (Disabled as default)
 ```
-
-And there are [some convenience features for Vue stack](https://hmsk.github.io/frontmatter-markdown-loader/vue) 😉
 
 📚 See the [documentation](https://hmsk.github.io/frontmatter-markdown-loader/) for the further detail.
 
@@ -44,5 +47,5 @@ The loader got the breaking changes in the latest major update. The article whic
 
 ## License
 
-- [MIT](LICENSE) Copyright 2018-present Kengo Hamasaki
-- [Contributors](https://github.com/hmsk/frontmatter-markdown-loader/graphs/contributors)
+- [MIT License](LICENSE) Copyright 2018-present Kengo Hamasaki
+- And thanks for [Contributors](https://github.com/hmsk/frontmatter-markdown-loader/graphs/contributors)

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,6 +7,7 @@ module.exports = {
           node: 'current'
         }
       }
-    ]
+    ],
+    '@babel/preset-react'
   ]
 };

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -13,7 +13,8 @@ module.exports = {
         children: [
           ['/', 'Setup'],
           ['/options', 'Options'],
-          ['/vue', 'Vue compilation'],
+          ['/vue', 'Vue Compoent/Renderers'],
+          ['/react', 'React Component']
         ]
       },
       {

--- a/docs/options.md
+++ b/docs/options.md
@@ -24,6 +24,7 @@ You may not want to import `frontmatter-markdown-loader/mode`. Then you can just
 - `Mode.META` -> `"meta"`
 - `Mode.VUE_COMPONENT` -> `"vue-component"`
 - `Mode.VUE_RENDER_FUNCTIONS` -> `"vue-render-functions"`
+- `Mode.REACT` -> `"react-component"`
 :::
 
 ### Default
@@ -140,6 +141,30 @@ fm.vue.staticRenderFns //=> List of staticRender function as string
 
 ::: tip How to use in Vue
 To see the usage of `fm.vue.component`, see [this page](/vue).
+:::
+
+### React component
+
+`Mode.VUE_COMPONENT` requests to get the extendable component object of Vue.
+
+```js
+{
+  test: /\.md$/,
+  loader: 'frontmatter-markdown-loader'
+  options: {
+    mode: [Mode.REACT]
+  }
+}
+```
+
+```js
+import fm from "something.md"
+
+fm.react //=> The function which is renderable as React component which has compiled markdown as template
+```
+
+::: tip How to use in React
+To see the usage of `fm.react`, see [this page](/react).
 :::
 
 ## Markdown compilation

--- a/docs/react.md
+++ b/docs/react.md
@@ -1,0 +1,56 @@
+# React Component
+
+By `Mode.REACT`, importing `.md` returns `react` property which is renderable React component as well as `Mode.VUE_COMPONENT`.
+
+```js
+import React from 'react'
+
+import { react as Sample } from './sample.md' // <-- THIS
+
+export default function OneComponent() {
+  return (
+    <div>
+      <h1>Content</h1>
+      <Sample /> <!-- This renders compiled markdown! -->
+    </div>
+  );
+}
+```
+
+## The React component can takes prop for components on markdown
+
+```md
+---
+title: A frontmatter
+description: Having ExternalComponent on the content
+---
+
+Hi, I'm a component. <MyDecorator>Apparently, this sentence will be made bold and italic</MyDecorator>
+```
+
+```js
+import React from 'react'
+import { react as Sample } from './sample.md'
+
+export default function DecoratedMarkdown() {
+  const BoldAndItalic = ({children}) => <strong><i>{children}</i></strong>
+
+  return (
+    <div>
+      <h1>Content</h1>
+      <Sample MyDecorator={BoldAndItalic} />
+    </div>
+  );
+}
+```
+
+Then `DecoratedMarkdown` renders:
+
+```html
+<div>
+  <h1>Content</h1>
+  <p>Hi, I'm a component. <strong><i>Apparently, this sentence will be made bold and italic</i></strong></p>
+</div>
+```
+
+`MyDecorator` isn't the specific name for props. We can specify any external component with PascalCase.

--- a/docs/vue.md
+++ b/docs/vue.md
@@ -1,8 +1,8 @@
-# Vue compilation
+# Vue Component/Renderers
 
 frontmatter-markdown-loader allows you to import the compiled markdown body as **Vue's render function**, **Vue component**.
 
-Those feature is enabled by `MODE.VUE_COMPONENT`, `MODE.VUE_RENDER_FUNCTIONS` in ["mode" option](mode#vue-component).
+Those feature is enabled by `Mode.VUE_COMPONENT`, `Mode.VUE_RENDER_FUNCTIONS` in ["mode" option](mode#vue-component).
 
 ::: warning Additional dependencies
 To use this mode, your project need to install [vue-template-compiler](https://www.npmjs.com/package/vue-template-compiler) and [vue-template-es2015-compiler](https://www.npmjs.com/package/vue-template-es2015-compiler).

--- a/mode.js
+++ b/mode.js
@@ -3,5 +3,6 @@ module.exports = {
   BODY: 'body',
   META: 'meta',
   VUE_COMPONENT: 'vue-component',
-  VUE_RENDER_FUNCTIONS: 'vue-render-functions'
+  VUE_RENDER_FUNCTIONS: 'vue-render-functions',
+  REACT: 'react-component'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,14 +1423,6 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-          "dev": true
-        }
       }
     },
     "@babel/template": {
@@ -1903,12 +1895,6 @@
             "js-levenshtein": "^1.1.3",
             "semver": "^5.3.0"
           }
-        },
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-          "dev": true
         }
       }
     },
@@ -3925,6 +3911,12 @@
           "dev": true
         }
       }
+    },
+    "core-js": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,16 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0",
+        "esutils": "^2.0.0"
+      }
+    },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
@@ -1041,6 +1051,46 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+      "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
@@ -1335,6 +1385,19 @@
             "unicode-match-property-value-ecmascript": "^1.1.0"
           }
         }
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.6.3.tgz",
+      "integrity": "sha512-07yQhmkZmRAfwREYIQgW0HEwMY9GBJVuPY4Q12UC72AbfaawuupVWa8zQs2tlL+yun45Nv/1KreII/0PLfEsgA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
     "@babel/runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmatter-markdown-loader",
-  "version": "2.2.0",
+  "version": "2.3.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,6 +1423,14 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        }
       }
     },
     "@babel/template": {
@@ -1683,9 +1691,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-      "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1696,9 +1704,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
+      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -1895,6 +1903,12 @@
             "js-levenshtein": "^1.1.3",
             "semver": "^5.3.0"
           }
+        },
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
         }
       }
     },
@@ -3911,12 +3925,6 @@
           "dev": true
         }
       }
-    },
-    "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-      "dev": true
     },
     "core-js-compat": {
       "version": "3.2.1",
@@ -9966,6 +9974,17 @@
         "sisteransi": "^1.0.3"
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -10133,11 +10152,34 @@
         }
       }
     },
+    "react": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
+      "integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
       "dev": true
+    },
+    "react-test-renderer": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.10.2.tgz",
+      "integrity": "sha512-k9Qzyev6cTIcIfrhgrFlYQAFxh5EEDO6ALNqYqmKsWVA7Q/rUMTay5nD3nthi6COmYsd4ghVYyi8U86aoeMqYQ==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.16.2"
+      }
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -10587,6 +10629,16 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "schema-utils": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,6 +158,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
       "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/types": "^7.3.0",
         "esutils": "^2.0.0"
@@ -1056,6 +1057,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
       "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1065,6 +1067,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
       "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.3.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1076,6 +1079,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
       "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -1086,6 +1090,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
       "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -1392,6 +1397,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.6.3.tgz",
       "integrity": "sha512-07yQhmkZmRAfwREYIQgW0HEwMY9GBJVuPY4Q12UC72AbfaawuupVWa8zQs2tlL+yun45Nv/1KreII/0PLfEsgA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-transform-react-display-name": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@babel/core": "7.6.4",
     "@babel/preset-env": "7.6.3",
+    "@babel/preset-react": "^7.6.3",
     "@vue/test-utils": "1.0.0-beta.29",
     "jest": "24.9.0",
     "node-eval": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontmatter-markdown-loader",
   "version": "2.3.0-0",
-  "description": "Webpack loader for Front Matter-ed Markdown file to get frontmatter attributes and compiled Vue component",
+  "description": "Webpack loader for Front Matter Markdown file to get front matter attributes, compiled markdown and React/Vue component which renders compiled markdown",
   "main": "index.js",
   "scripts": {
     "test": "jest",
@@ -19,7 +19,8 @@
     "markdown",
     "frontmatter",
     "vue",
-    "loader"
+    "loader",
+    "react"
   ],
   "author": "Kengo Hamasaki <k.hamasaki@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,15 @@
     "markdown-it": "^10.0.0"
   },
   "optionalDependencies": {
+    "@babel/core": "^7.6.0",
+    "@babel/preset-react": "^7.6.0",
     "vue-template-compiler": "^2.5.0",
     "vue-template-es2015-compiler": "^1.6.0"
   },
   "devDependencies": {
     "@babel/core": "7.6.4",
     "@babel/preset-env": "7.6.3",
-    "@babel/preset-react": "^7.6.3",
+    "@babel/preset-react": "7.6.3",
     "@vue/test-utils": "1.0.0-beta.29",
     "jest": "24.9.0",
     "node-eval": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmatter-markdown-loader",
-  "version": "2.2.0",
+  "version": "2.3.0-0",
   "description": "Webpack loader for Front Matter-ed Markdown file to get frontmatter attributes and compiled Vue component",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/core": "7.6.4",
     "@babel/preset-env": "7.6.3",
     "@babel/preset-react": "7.6.3",
+    "@vue/babel-preset-app": "^3.12.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "jest": "24.9.0",
     "node-eval": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@vue/test-utils": "1.0.0-beta.29",
     "jest": "24.9.0",
     "node-eval": "2.0.0",
+    "react": "16.10.2",
+    "react-test-renderer": "16.10.2",
     "vue": "2.6.10",
     "vue-jest": "4.0.0-beta.2",
     "vue-template-compiler": "2.6.10",
@@ -56,7 +58,8 @@
     "testURL": "http://localhost",
     "moduleFileExtensions": [
       "js",
-      "vue"
+      "vue",
+      "json"
     ],
     "transform": {
       "^.+\\.js$": "babel-jest",

--- a/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
+++ b/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frontmatter-markdown-loader react mode returns renderable React component 1`] = `
+<div>
+  <h1>
+    Title
+  </h1>
+  <p>
+    GOOD 
+    <code>
+      BYE
+    </code>
+     FRIEND CHEERS
+  </p>
+</div>
+`;
+
+exports[`frontmatter-markdown-loader react mode returns renderable React component with accepting child components through props 1`] = `
+<div>
+  <h1>
+    Title
+  </h1>
+  <p>
+    HELLO
+    <strong>
+      I am a child
+    </strong>
+  </p>
+  <p>
+    <i>
+      I am another
+    </i>
+  </p>
+</div>
+`;

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -88,6 +88,10 @@ describe("frontmatter-markdown-loader", () => {
     it("doesn't return 'vue' property", () => {
       expect(loaded.vue).toBeUndefined();
     });
+
+    it("doesn't return 'react' property", () => {
+      expect(loaded.react).toBeUndefined();
+    });
   });
 
   describe("markdown option", () => {

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -1,4 +1,7 @@
 import { mount, createLocalVue } from "@vue/test-utils";
+import reactRenderer from 'react-test-renderer';
+import React from 'react';
+
 import markdownIt from "markdown-it";
 import nodeEval from "node-eval";
 
@@ -16,7 +19,7 @@ const defaultContext = {
 
 const load = (source, context = defaultContext) => {
   const rawLoaded = Loader.call(context, source);
-  loaded = nodeEval(rawLoaded);
+  loaded = nodeEval(rawLoaded, "sample.md");
 }
 
 const markdownWithFrontmatter = `---
@@ -252,4 +255,36 @@ describe("frontmatter-markdown-loader", () => {
       });
     });
   });
+
+  const markdownWithFrontmatterIncludingPascalChildComponent = `---
+subject: Hello
+tags:
+  - tag1
+  - tag2
+---
+# Title
+
+HELLO
+<ChildComponent />
+
+<AnotherChild>I am another</AnotherChild>
+`;
+
+  describe("react mode", () => {
+    it("returns renderable React component", () => {
+      load(markdownWithFrontmatter, { ...defaultContext, query: { mode: [Mode.REACT] } });
+      const MarkdownComponent = loaded.react;
+      const rendered = reactRenderer.create(<MarkdownComponent />);
+      expect(rendered.toJSON()).toMatchSnapshot();
+    });
+
+    it("returns renderable React component with accepting child components through props", () => {
+      load(markdownWithFrontmatterIncludingPascalChildComponent, { ...defaultContext, query: { mode: [Mode.REACT] } });
+      const MarkdownComponent = loaded.react;
+      const ChildComponent = () => <strong>I am a child</strong>
+      const AnotherChild = ({ children }) => <i>{children}</i>
+      const rendered = reactRenderer.create(<MarkdownComponent ChildComponent={ChildComponent} AnotherChild={AnotherChild} />);
+      expect(rendered.toJSON()).toMatchSnapshot();
+    });
+  })
 });


### PR DESCRIPTION
# ToDo

- [x] Add tests
- [x] Add docs

# `Mode.REACT` (`"react-component"`)

## Importing `.md` returns `react` property which is renderable React component

```js
import React from 'react'

import { react as Sample } from './sample.md' // <-- THIS

export default function OneComponent() {
  return (
    <div>
      <h1>Content</h1>
      <Sample /> <!-- This renders compiled markdown! -->
    </div>
  );
}
```

## The React component takes props for components on markdown

```md
---
title: A frontmatter
description: Having ExternalComponent on the content
---

Hi, I'm a component. <External Component>Apparently, this sentence will be made bold and italic</ExternalComponent>
```

```js
import React from 'react'
import { react as Sample } from './sample.md'

export default function OneComponent() {
  const ExternalComponent = ({children}) => <strong><i>{children}</i></strong>

  return (
    <div>
      <h1>Content</h1>
      <Sample ExternalComponent={ExternalComponent} />
    </div>
  );
}
```

Then OneComponent renders:

```html
<div>
  <h1>Content</h1>
  <p>Hi, I'm a component. <strong><i>Apparently, this sentence will be made bold and italic</i></strong></p>
</div>
```

`ExternalComponent` isn't the specific name for props. We can specify any external component with PascalCase.