### PR TITLE
Use @vue/component-compiler-utils to compile Vue template

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -28,7 +28,7 @@ module.exports = {
         title: 'Migration',
         collapsable: false,
         children: [
-          ['/migration', 'Migration from 1.x'],
+          ['/migration', 'If you have update major version'],
         ]
       }
     ]

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,4 +1,30 @@
-# Migration from 1.x
+# Migrate to `3.*`
+
+If you're using `vue.component`, `vue.render` or `vue.staticRenderFns` by importing.
+
+On the template for Vue component by compiling markdown,
+
+- Source attributes for `img`, `video`, `source`, `image`, `use` tag
+- ![alt text](Image URL) on Markdown
+
+are transformed as Webpack env's assets like `require(originalPath)` as default.
+
+To disable, give `vue.transformAssetUrls: false`.
+
+```js
+{
+  test: /\.md$/,
+  loader: 'frontmatter-markdown-loader'
+  options: {
+    mode: [Mode.VUE_COMPONENT]
+    vue: {
+      transformAssetUrls: false
+    }
+  }
+}
+```
+
+# Migrate to `2.*`/`3.*` from `1.*`
 
 From `2.0.0`, `mode` is added to load contents selectively. That was breaking change but compresses the build size a lot.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -221,7 +221,11 @@ To provide the custom compilation logic, `markdown` option accepts the callback 
 }
 ```
 
-## Vue's root element
+## Vue Compilation
+
+### Class name for root `div` element
+
+`vue.root` option configures the class name of the root `div` element on Vue component's template.
 
 ```js
 {
@@ -235,4 +239,64 @@ To provide the custom compilation logic, `markdown` option accepts the callback 
 }
 ```
 
-can specify the class name of the root element on the imported Vue's template.
+By this configuration, the HTML in the below will be rendered by the Vue component.
+
+```js
+<div class="dynamicContent">
+  <h1>Title</h1>
+  <p>Main sentences</p>
+</div>
+```
+
+Default is `frontmatter-markdown`.
+
+### Assets transformation
+
+`vue.transformAssetUrls` configures assets handling on HTML which expects an key-value pair with element's name for key, an attribute names as array for value.
+
+Thus, `{ img: ['src', 'data-src'] }` means, `img` tag's `src` attribute and `data-src` attribute.
+
+Matched attributes are replaced with `require(originalValue)` on Vue template compilation. So, Webpack treats them as other resources. Typically, `file-loader`, `url-loader` gives Base 64 string, another path with asset's id. [Vue CLI App](https://cli.vuejs.org/guide/html-and-static-assets.html#static-assets-handling) and [Nuxt.js](https://nuxtjs.org/guide/assets#webpack) works with this behavior harmonically.
+
+Default is `true` which means:
+
+```js
+{
+  video: ['src', 'poster'],
+  source: 'src',
+  img: 'src',
+  image: ['xlink:href', 'href'],
+  use: ['xlink:href', 'href']
+}
+```
+
+This option will be merged with the default.
+
+```js
+{
+  test: /\.md$/,
+  loader: 'frontmatter-markdown-loader'
+  options: {
+    vue: {
+      transformAssetUrls: {
+        img: ['src', 'data-src']
+      }
+    }
+  }
+}
+```
+
+So, the configuration becomes eventually:
+
+```diff
+{
+  video: ['src', 'poster'],
+  source: 'src',
+- img: 'src',
++ img: ['src', 'data-src']
+  image: ['xlink:href', 'href'],
+  use: ['xlink:href', 'href']
+}
+```
+
+To disable all completely, just give `false`.

--- a/docs/vue.md
+++ b/docs/vue.md
@@ -5,7 +5,18 @@ frontmatter-markdown-loader allows you to import the compiled markdown body as *
 Those feature is enabled by `Mode.VUE_COMPONENT`, `Mode.VUE_RENDER_FUNCTIONS` in ["mode" option](mode#vue-component).
 
 ::: warning Additional dependencies
-To use this mode, your project need to be installed [vue-template-compiler](https://www.npmjs.com/package/vue-template-compiler) and [vue-template-es2015-compiler](https://www.npmjs.com/package/vue-template-es2015-compiler).
+To use this mode, your project need to be installed some dependencies.
+
+### After 3.0.0
+
+- [vue-template-compiler](https://www.npmjs.com/package/vue-template-compiler)
+- [@vue/component-compiler-utils](https://www.npmjs.com/package/@vue/component-compiler-utils)
+
+### Until 2.3.0
+
+- [vue-template-compiler](https://www.npmjs.com/package/vue-template-compiler)
+- [vue-template-es2015-compiler](https://www.npmjs.com/package/vue-template-es2015-compiler)
+
 :::
 
 ## Extendable component
@@ -27,7 +38,39 @@ export default {
 
 ## Render functions
 
-`render` and `staticRenderFns` are necessary member of Vue's component internally. The loader can return these and we can call in the hand-made Vue component. Then you can inject components as sub-components. If the markdown body has the matching HTML tag to their name, Vue will run as Vue component 🧙‍♀️.
+`render` and `staticRenderFns` are necessary members of Vue's component internally. The loader can return these and we can call in the hand-made Vue component. Then you can inject components as sub-components. If the markdown body has the matching HTML tag to their name, Vue will run as Vue component 🧙‍♀️.
+
+### After 3.0.0
+
+```js
+import fm from "something.md"
+import OtherComponent from "OtherComponent.vue"
+
+export default {
+  data () {
+    return {
+      templateRender: null
+    }
+  },
+
+  components: {
+    OtherComponent // If markdown has `<other-component>` in body, will work :)
+  },
+
+  render (createElement) {
+    return this.templateRender ? this.templateRender() : createElement("div", "Rendering");
+  },
+
+  created () {
+    this.templateRender = fm.vue.render;
+    this.$options.staticRenderFns = fm.vue.staticRenderFns;
+  }
+}
+```
+
+### Until 2.3.0
+
+`vue.render` and `vue.staticRenderFns` were just the string of the source.
 
 ```js
 import fm from "something.md"

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = function (source) {
       compilerOptions: {
         outputSourceRange: true
       },
-      transformAssetUrls: true,
+      transformAssetUrls: (options.vue && options.vue.transformAssetUrls) ? options.vue.transformAssetUrls : true,
       isProduction: process.env.NODE_ENV === 'production'
     };
 

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = function (source) {
       compilerOptions: {
         outputSourceRange: true
       },
-      transformAssetUrls: (options.vue && options.vue.transformAssetUrls) ? options.vue.transformAssetUrls : true,
+      transformAssetUrls: (options.vue && (options.vue.transformAssetUrls === false || options.vue.transformAssetUrls)) ? options.vue.transformAssetUrls : true,
       isProduction: process.env.NODE_ENV === 'production'
     };
 

--- a/index.js
+++ b/index.js
@@ -129,6 +129,8 @@ module.exports = function (source) {
   }
 
   if (enabled(Mode.REACT)) {
+    addPrepend(`const React = require('react')`);
+
     const compiled = babelCore
       .transformSync(`
         const markdown =
@@ -143,8 +145,7 @@ module.exports = function (source) {
       function (props) {
         Object.entries(props).forEach(([key, value]) => {
           this[key] = value;
-        })
-        const React = require('react');
+        });
         ${compiled.code}
         return markdown;
       }

--- a/index.js
+++ b/index.js
@@ -5,10 +5,9 @@ const markdownIt = require('markdown-it');
 
 const stringify = (src) => JSON.stringify(src).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
 
-let compileVueTemplate, vueCompiler, vueCompilerStripWith, babelCore
+let compileVueTemplate, vueCompiler, babelCore
 try {
   vueCompiler = require('vue-template-compiler')
-  vueCompilerStripWith = require('vue-template-es2015-compiler')
   compileVueTemplate = require('@vue/component-compiler-utils').compileTemplate
 } catch (err) {
 }
@@ -77,7 +76,7 @@ module.exports = function (source) {
     addProperty('meta', stringify(meta));
   }
 
-  if ((enabled(Mode.VUE_COMPONENT) || enabled(Mode.VUE_RENDER_FUNCTIONS)) && vueCompiler && vueCompilerStripWith && compileVueTemplate) {
+  if ((enabled(Mode.VUE_COMPONENT) || enabled(Mode.VUE_RENDER_FUNCTIONS)) && vueCompiler && compileVueTemplate) {
     const rootClass = options.vue && options.vue.root ? options.vue.root : 'frontmatter-markdown';
     const template = fm
       .html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmatter-markdown-loader",
-  "version": "2.3.0",
+  "version": "3.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,10 +1922,11 @@
       }
     },
     "@vue/component-compiler-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
-      "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.0.0.tgz",
+      "integrity": "sha512-am+04/0UX7ektcmvhYmrf84BDVAD8afFOf4asZjN84q8xzxFclbk5x0MtxuKGfp+zjN5WWPJn3fjFAWtDdIGSw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "consolidate": "^0.15.1",
         "hash-sum": "^1.0.2",
@@ -1942,7 +1943,8 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12317,6 +12319,33 @@
         "extract-from-css": "^0.4.4",
         "source-map": "^0.5.6",
         "ts-jest": "^23.10.5"
+      },
+      "dependencies": {
+        "@vue/component-compiler-utils": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+          "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+          "dev": true,
+          "requires": {
+            "consolidate": "^0.15.1",
+            "hash-sum": "^1.0.2",
+            "lru-cache": "^4.1.2",
+            "merge-source-map": "^1.1.0",
+            "postcss": "^7.0.14",
+            "postcss-selector-parser": "^5.0.0",
+            "prettier": "1.16.3",
+            "source-map": "~0.6.1",
+            "vue-template-es2015-compiler": "^1.9.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "vue-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmatter-markdown-loader",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmatter-markdown-loader",
-  "version": "2.3.0",
+  "version": "3.0.0-0",
   "description": "Webpack loader for Front Matter Markdown file to get front matter attributes, compiled markdown and React/Vue component which renders compiled markdown",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "@babel/core": "^7.6.0",
     "@babel/preset-react": "^7.6.0",
     "@vue/component-compiler-utils": "^3.0.0",
-    "vue-template-compiler": "^2.5.0",
-    "vue-template-es2015-compiler": "^1.6.0"
+    "vue-template-compiler": "^2.5.0"
   },
   "devDependencies": {
     "@babel/core": "7.6.4",
@@ -54,7 +53,6 @@
     "vue": "2.6.10",
     "vue-jest": "4.0.0-beta.2",
     "vue-template-compiler": "2.6.10",
-    "vue-template-es2015-compiler": "1.9.1",
     "vuepress": "1.2.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmatter-markdown-loader",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "description": "Webpack loader for Front Matter Markdown file to get front matter attributes, compiled markdown and React/Vue component which renders compiled markdown",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "optionalDependencies": {
     "@babel/core": "^7.6.0",
     "@babel/preset-react": "^7.6.0",
+    "@vue/component-compiler-utils": "^3.0.0",
     "vue-template-compiler": "^2.5.0",
     "vue-template-es2015-compiler": "^1.6.0"
   },
@@ -44,6 +45,7 @@
     "@babel/preset-env": "7.6.3",
     "@babel/preset-react": "7.6.3",
     "@vue/babel-preset-app": "4.0.4",
+    "@vue/component-compiler-utils": "3.0.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "jest": "24.9.0",
     "node-eval": "2.0.0",

--- a/test/avatar.png.js
+++ b/test/avatar.png.js
@@ -1,0 +1,2 @@
+// 'require' by node-eval evades jest's mocking/transform, so just make a fake file for avatar.png
+module.exports = "avatar-through-require.png"

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -43,9 +43,11 @@ tags:
 # Title
 
 HELLO
-<child-component>
+<child-component />
 
 <code-confusing />
+
+<img src="./avatar.png.js" />
 
 \`\`\`html
 <child-component>{{ test->() }}</child-component>
@@ -165,8 +167,8 @@ describe("frontmatter-markdown-loader", () => {
         },
 
         created: function () {
-          this.templateRender = new Function(loaded.vue.render)();
-          this.$options.staticRenderFns = new Function(loaded.vue.staticRenderFns)();
+          this.templateRender = loaded.vue.render;
+          this.$options.staticRenderFns = loaded.vue.staticRenderFns;
         }
       }
     };
@@ -242,6 +244,16 @@ describe("frontmatter-markdown-loader", () => {
         const wrapper = mountComponent(component);
         expect(wrapper.find(ChildComponent).exists()).toBe(true);
         expect(wrapper.find(".childComponent").text()).toBe("Child Vue Component olloeh");
+      });
+
+      it("replace image", () => {
+        load(markdownWithFrontmatterIncludingChildComponent, contextEnablingVueComponent());
+        const component = {
+          extends: loaded.vue.component,
+          components: { ChildComponent, CodeConfusing }
+        };
+        const wrapper = mountComponent(component);
+        expect(wrapper.find("img").attributes("src")).toBe("avatar-through-require.png");
       });
 
       it("avoids compiling code snipets on markdown", () => {

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -47,7 +47,7 @@ HELLO
 
 <code-confusing />
 
-<img src="./avatar.png.js" />
+![Avatar Image](./avatar.png.js)
 
 \`\`\`html
 <child-component>{{ test->() }}</child-component>

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -246,7 +246,7 @@ describe("frontmatter-markdown-loader", () => {
         expect(wrapper.find(".childComponent").text()).toBe("Child Vue Component olloeh");
       });
 
-      it("replace image", () => {
+      it("transforms asset's URL as default", () => {
         load(markdownWithFrontmatterIncludingChildComponent, contextEnablingVueComponent());
         const component = {
           extends: loaded.vue.component,
@@ -254,6 +254,16 @@ describe("frontmatter-markdown-loader", () => {
         };
         const wrapper = mountComponent(component);
         expect(wrapper.find("img").attributes("src")).toBe("avatar-through-require.png");
+      });
+
+      it("doesn't transform asset's URL as configured", () => {
+        load(markdownWithFrontmatterIncludingChildComponent, contextEnablingVueComponent({ vue: { transformAssetUrls: { img: null } } }));
+        const component = {
+          extends: loaded.vue.component,
+          components: { ChildComponent, CodeConfusing }
+        };
+        const wrapper = mountComponent(component);
+        expect(wrapper.find("img").attributes("src")).toBe("./avatar.png.js");
       });
 
       it("avoids compiling code snipets on markdown", () => {

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -266,6 +266,16 @@ describe("frontmatter-markdown-loader", () => {
         expect(wrapper.find("img").attributes("src")).toBe("./avatar.png.js");
       });
 
+      it("doesn't transform asset's URL as disabled", () => {
+        load(markdownWithFrontmatterIncludingChildComponent, contextEnablingVueComponent({ vue: { transformAssetUrls: false } }));
+        const component = {
+          extends: loaded.vue.component,
+          components: { ChildComponent, CodeConfusing }
+        };
+        const wrapper = mountComponent(component);
+        expect(wrapper.find("img").attributes("src")).toBe("./avatar.png.js");
+      });
+
       it("avoids compiling code snipets on markdown", () => {
         load(markdownWithFrontmatterIncludingChildComponent, contextEnablingVueComponent());
         const component = {


### PR DESCRIPTION
Resolves #41 (and the part of #20) finally.
This PR will be delivered as 3.0.0-N to have a testing period.

## Assets path in markdown body will be transformed

`<img src="./img/something.png" />` ➡ `require("./img/something.png")`

It's using `@vue/component-compiler-utils` which is used for vue-loader. So this change will support Nuxt's `~/assets/image.png` naturally.

## Breaking Changes

- Relative path for those tags on Markdown body will be replaced with `require` as like vue-loader
    - `video` element: `src`, `poster` attribute
    - `source` element: `src` attribute
    - `img` element: `src` attribute
    - `image` element: `xlink:href`, `href` attribute
    - `use` element: `xlink:href`, `href` attribute
- Custom element should have "closing tag" always
    - `@vue/component-compiler-utils` doesn't allow un-closed tag to compile template apparently
- `vue.render`, `vue.staticRenderFns` return function instead of source string