### PR TITLE
Added a few Nuxt examples

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -21,7 +21,8 @@ module.exports = {
         title: 'Samples',
         collapsable: false,
         children: [
-          ['/samples-vue', 'Vue App']
+          ['/samples-vue', 'Vue App'],
+          ['/samples-nuxt', 'Nuxt App']
         ]
       },
       {

--- a/docs/samples-nuxt.md
+++ b/docs/samples-nuxt.md
@@ -1,0 +1,67 @@
+# Nuxt examples
+
+## Register the loader through `nuxt.config.js`
+
+```ts
+import FMMode from "frontmatter-markdown-loader/mode";
+
+  ...
+  build: {
+    extend (config: any): void {
+      config.module.rules.push(
+        {
+          test: /\.md$/,
+          loader: "frontmatter-markdown-loader",
+          include: episodeDir,
+          options: {
+            mode: [FMMode.VUE_COMPONENT],
+            vue: {
+              root: "episodeMarkdown"
+            },
+            markdown: (body: string) => {
+              return md.render(body);
+            }
+          }
+        }
+      )
+    },
+    ...
+  }
+  ...
+```
+
+## Using Vue component mode in a static template
+
+```js
+<template>
+  <StaticMarkdownComponent />
+</template>
+
+<script>
+import StaticMarkdownComponent from '~/README.md'
+
+export default {
+  components: { StaticMarkdownComponent: StaticMarkdownComponent.vue.component }
+}
+</script>
+```
+
+## Using Vue component mode in a dynamic template
+
+Instantiate a [Vue async component](https://vuejs.org/v2/guide/components-dynamic-async.html#Async-Components) in create lifecycle hook which gets [executed during server-side-render](https://ssr.vuejs.org/guide/universal.html#data-reactivity-on-the-server).
+
+```js
+<template>
+  <component :is="dynamicMarkdownComponent" />
+</template>
+
+<script>
+export default {
+  data: () => ({ dynamicMarkdownComponent: null }),
+  created () {
+    this.dynamicMarkdownComponent = async () =>
+      (await import(`~/content/${this.$route.id}`)).vue.component
+  }
+}
+</script>
+```

--- a/docs/samples-vue.md
+++ b/docs/samples-vue.md
@@ -25,37 +25,3 @@ module.exports = {
   }
 }
 ```
-
-# Nuxt app
-
-::: warning TBD
-Will be filled with nice samples later
-:::
-
-```ts
-import FMMode from "frontmatter-markdown-loader/mode";
-
-  ...
-  build: {
-    extend (config: any): void {
-      config.module.rules.push(
-        {
-          test: /\.md$/,
-          loader: "frontmatter-markdown-loader",
-          include: episodeDir,
-          options: {
-            mode: [FMMode.VUE_COMPONENT],
-            vue: {
-              root: "episodeMarkdown"
-            },
-            markdown: (body: string) => {
-              return md.render(body);
-            }
-          }
-        }
-      )
-    },
-    ...
-  }
-  ...
-```


### PR DESCRIPTION
@hmsk I think this should help some people out.

One last thing that I'm having trouble with is accessing attributes when using an async component. I can do it easily by loading the file one more time in asyncData and saving the attributes there, however loading the file twice is probably not a great solution.

```vue
<template>
  <div>
    <h1>{{ attributes.title }}</h1>
    <component :is="dynamicMarkdownComponent" />
  </div>
</template>

<script>
export default {
  data: () => ({ dynamicMarkdownComponent: null }),
  asyncData: async ({ params }) => ({
    attributes: (await import(`~/content/${this.$route.id}`)).attributes
  }),
  created () {
    this.dynamicMarkdownComponent = async () =>
      (await import(`~/content/${this.$route.id}`)).vue.component
  }
}
</script>
```

I also tried making the created lifecycle hook async and loading the attributes there. That partially kind of worked, except only on the client. Perhaps I'm doing it wrong.

```vue
<script>
export default {
  data: () => ({ dynamicMarkdownComponent: null, attributes: {} }),
  async created () {
    this.file = import(`~/content/${this.$route.id}`)
    this.dynamicMarkdownComponent = async () => (await this.file).vue.component
    this.attributes = (await this.file).attributes
  }
}
</script>
```

Would there be a way of doing this server side without loading the file twice?