### PR TITLE
Give xhtmlOut: true for markdown-it as default for REACT mode

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -189,7 +189,7 @@ By default, the loader compiles markdown with [markdown-it](https://github.com/m
 
 [Refer markdown-it document for the further about the configuration](https://github.com/markdown-it/markdown-it#init-with-presets-and-options).
 
-If `markdownIt` option isn't given, the loader uses `markdown-it` with just `{ html: true}` as default.
+If `markdownIt` option isn't given, the loader uses `markdown-it` with just `{ html: true}` as default. (If enabled `Mode.REACT`, `{ html: true, xhtmlOut: true }`)
 
 `markdonIt` option also accepts the instance of a markdown-it rederer (with [plugins](https://www.npmjs.com/search?q=keywords:markdown-it-plugin), for instance):
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -108,6 +108,10 @@ Currently, only `resourcePath` is available which returns [the path for the file
 }
 ```
 
+::: tip How to use in React
+To see the usage of `fm.react`, see [this page](react).
+:::
+
 ### Vue component
 
 `Mode.VUE_COMPONENT` requests to get the extendable component object of Vue.

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const markdownIt = require('markdown-it');
 
 const stringify = (src) => JSON.stringify(src).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
 
-function getNormalizedMarkdownCompiler(options) {
+function getNormalizedMarkdownCompiler (options, isReactEnabled) {
   if (options.markdown && options.markdownIt) {
     throw new Error(
       "Both markdown and markdownIt options were specified. This is not supported. \n" +
@@ -30,7 +30,7 @@ function getNormalizedMarkdownCompiler(options) {
   }
 
   // If no configuration is passed - use a sensible default
-  return markdownIt({ html: true });
+  return markdownIt(isReactEnabled ? { html: true, xhtmlOut: true } : { html: true });
 }
 
 module.exports = function (source) {
@@ -51,7 +51,7 @@ module.exports = function (source) {
   };
 
   const fm = frontmatter(source);
-  const markdownCompiler = getNormalizedMarkdownCompiler(options);
+  const markdownCompiler = getNormalizedMarkdownCompiler(options, enabled(Mode.REACT));
   fm.html = markdownCompiler.render(fm.body);
 
   addProperty('attributes', stringify(fm.attributes));

--- a/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
+++ b/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
@@ -31,5 +31,11 @@ exports[`frontmatter-markdown-loader react mode returns renderable React compone
       I am another
     </i>
   </p>
+  <p>
+    <img
+      alt="Awewsome Photo"
+      src="/assets/awesome-photo.jpg"
+    />
+  </p>
 </div>
 `;

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -357,6 +357,8 @@ HELLO
 <ChildComponent />
 
 <AnotherChild>I am another</AnotherChild>
+
+![Awewsome Photo](/assets/awesome-photo.jpg)
 `;
 
   describe("react mode", () => {


### PR DESCRIPTION
Resolves #114 

JSX expects self-closing tag like `<img />` as XHTML rather than `<img>`.