### PR TITLE
IE11 Compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,9 @@ module.exports = function (source) {
 
     const reactComponent = `
       function (props) {
-        Object.entries(props).forEach(([key, value]) => {
+        Object.entries(props).forEach(function (prop) {
+          const key = prop[0]
+          const value = prop[1]
           this[key] = value;
         });
         ${compiled.code}


### PR DESCRIPTION
I followed [this tutorial](https://www.netlifycms.org/docs/nextjs/) to use `frontmatter-markdown-loader` with NetlifyCMS and NextJS.  I noticed the site isn't IE11 compatible because of an arrow function from this package.

I tried using [next-transpile-modules](https://github.com/martpie/next-transpile-modules) to automatically fix the arrow function with no avail.

Instead, here is a PR to change the arrow function to an IE11 compatible function.