### PR TITLE
Use ES5 Object Creation Shorthand

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = function (source) {
     };
 
     const compiled = compileVueTemplate(compileOptions);
-    addPrepend(`function extractVueFunctions () {\n${compiled.code}\nreturn { render, staticRenderFns }\n}\nconst vueFunctions = extractVueFunctions()`);
+    addPrepend(`function extractVueFunctions () {\n${compiled.code}\nreturn { render:render, staticRenderFns:staticRenderFns }\n}\nconst vueFunctions = extractVueFunctions()`);
 
     let vueOutput = '';
 


### PR DESCRIPTION
`return { render, staticRenderFns }` breaks in IE 11, because it doesn't support the ES6 object initialization shorthand