### PR TITLE
Use className instead of class in react mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = function (source) {
     const compiled = babelCore
       .transformSync(`
         const markdown =
-          <div class="${reactRootClass}">
+          <div className="${reactRootClass}">
             ${fm.html}
           </div>
         `, {

--- a/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
+++ b/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`frontmatter-markdown-loader react mode returns renderable React component 1`] = `
 <div
-  class="frontmatter-markdown"
+  className="frontmatter-markdown"
 >
   <h1>
     Title
@@ -19,7 +19,7 @@ exports[`frontmatter-markdown-loader react mode returns renderable React compone
 
 exports[`frontmatter-markdown-loader react mode returns renderable React component with accepting child components through props 1`] = `
 <div
-  class="frontmatter-markdown"
+  className="frontmatter-markdown"
 >
   <h1>
     Title
@@ -46,7 +46,7 @@ exports[`frontmatter-markdown-loader react mode returns renderable React compone
 
 exports[`frontmatter-markdown-loader react mode returns renderable React component with expected root class 1`] = `
 <div
-  class="forReact"
+  className="forReact"
 >
   <h1>
     Title


### PR DESCRIPTION
This PR gets rid of the warning message printed by React:
```
Warning: Invalid DOM property `class`. Did you mean `className`?
```