### PR TITLE
Fix template literal in code block

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ module.exports = function (source) {
 
     const template = fm
       .html
+      .replace(/(?<=<code(\s[^>]+)?>.*)`(?=.*<\/code>)/sg, "\\`")
       .replace(/<code(\s[^>]+)>(.+?)<\/code>/sg, "<code$1 dangerouslySetInnerHTML={{ __html: `$2`}} />")
       .replace(/<code>(.+?)<\/code>/sg, "<code dangerouslySetInnerHTML={{ __html: `$1`}} />")
       .replace(/<(code|pre)([^\s>]*)\sclass=([^>]+)>/g, "<$1$2 className=$3>")

--- a/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
+++ b/test/__snapshots__/frontmatter-markdown-loader.test.js.snap
@@ -23,7 +23,8 @@ exports[`frontmatter-markdown-loader react mode returns renderable React compone
       className="language-js"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "const multipleLine = true;
+          "__html": "const templateLiteral = \`ok\`;
+const multipleLine = true;
 console.warn(multipleLine)
 ",
         }
@@ -83,7 +84,8 @@ exports[`frontmatter-markdown-loader react mode returns renderable React compone
       className="language-js"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "const multipleLine = true;
+          "__html": "const templateLiteral = \`ok\`;
+const multipleLine = true;
 console.warn(multipleLine)
 ",
         }

--- a/test/frontmatter-markdown-loader.test.js
+++ b/test/frontmatter-markdown-loader.test.js
@@ -40,7 +40,7 @@ describe("frontmatter-markdown-loader", () => {
 
     it("returns compiled HTML for 'html' property", () => {
       expect(loaded.html).toBe(
-        "<h1>Title</h1>\n<p>GOOD <code>BYE</code> FRIEND\nCHEERS</p>\n<pre><code class=\"language-js\">const multipleLine = true;\nconsole.warn(multipleLine)\n</code></pre>\n"
+        "<h1>Title</h1>\n<p>GOOD <code>BYE</code> FRIEND\nCHEERS</p>\n<pre><code class=\"language-js\">const templateLiteral = `ok`;\nconst multipleLine = true;\nconsole.warn(multipleLine)\n</code></pre>\n"
       );
     });
 
@@ -85,7 +85,7 @@ describe("frontmatter-markdown-loader", () => {
     it("returns HTML with configured markdownIt: breaks option is enabled as configuration", () => {
       load(markdownWithFrontmatter, { ...defaultContext, query: { markdownIt: { breaks: true } } });
       expect(loaded.html).toBe(
-        "<h1>Title</h1>\n<p>GOOD <code>BYE</code> FRIEND<br>\nCHEERS</p>\n<pre><code class=\"language-js\">const multipleLine = true;\nconsole.warn(multipleLine)\n</code></pre>\n"
+        "<h1>Title</h1>\n<p>GOOD <code>BYE</code> FRIEND<br>\nCHEERS</p>\n<pre><code class=\"language-js\">const templateLiteral = `ok`;\nconst multipleLine = true;\nconsole.warn(multipleLine)\n</code></pre>\n"
       )
     });
 
@@ -101,7 +101,7 @@ describe("frontmatter-markdown-loader", () => {
 
       load(markdownWithFrontmatter, { ...defaultContext, query: { markdownIt: markdownItInstance } });
       expect(loaded.html).toBe(
-        "<h1>Title</h1>\n<p data-paragraph=\"hello\">GOOD <code>BYE</code> FRIEND\nCHEERS</p>\n<pre><code class=\"language-js\">const multipleLine = true;\nconsole.warn(multipleLine)\n</code></pre>\n"
+        "<h1>Title</h1>\n<p data-paragraph=\"hello\">GOOD <code>BYE</code> FRIEND\nCHEERS</p>\n<pre><code class=\"language-js\">const templateLiteral = `ok`;\nconst multipleLine = true;\nconsole.warn(multipleLine)\n</code></pre>\n"
       );
     });
   });
@@ -110,7 +110,7 @@ describe("frontmatter-markdown-loader", () => {
     it("returns raw markdown body for 'body' property", () => {
       load(markdownWithFrontmatter, { ...defaultContext, query: { mode: [Mode.BODY] } });
       expect(loaded.body).toBe(
-        "# Title\n\nGOOD `BYE` FRIEND\nCHEERS\n\n```js\nconst multipleLine = true;\nconsole.warn(multipleLine)\n```\n"
+        "# Title\n\nGOOD `BYE` FRIEND\nCHEERS\n\n```js\nconst templateLiteral = `ok`;\nconst multipleLine = true;\nconsole.warn(multipleLine)\n```\n"
       );
     });
   });

--- a/test/with-frontmatter.md
+++ b/test/with-frontmatter.md
@@ -10,6 +10,7 @@ GOOD `BYE` FRIEND
 CHEERS
 
 ```js
+const templateLiteral = `ok`;
 const multipleLine = true;
 console.warn(multipleLine)
 ```


### PR DESCRIPTION
Fix below problem by escaping backticks

**Problem**

This input causes JSX syntax error:

    ```
    const templateLiteral = `ok`;
    ```

because code blocks in React mode is converted into `dangerouslySetInnerHTML`.
Its template literal includes backticks.

Converted:

    <code dangerouslySetInnerHTML={{"__html": `const templateLiteral = `ok`;`}} />

We need to escape the backticks in backticks.