### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/hmsk/frontmatter-markdown-loader.git"
+    "url": "git+https://github.com/hmsk/frontmatter-markdown-loader.git"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
## Summary
- replace the package repository URL with the canonical HTTPS GitHub URL
- keep the existing bugs URL and homepage unchanged

## Validation
- metadata assertion for repository, bugs, and homepage fields
- git diff --check
- npm ci --ignore-scripts
- npm test (35 tests passed)
- npm pack --dry-run

This keeps the published package metadata installable and inspectable without requiring SSH GitHub access.